### PR TITLE
Add simple libk so print is available for outside crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/memory/buddy",
     "crates/memory/page",
     "crates/memory/slab",
+    "crates/libk",
     "kernel",
     "tests",
     "xtask",

--- a/crates/libk/Cargo.toml
+++ b/crates/libk/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "libk"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+common = { path = "../common" }

--- a/crates/libk/src/lib.rs
+++ b/crates/libk/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+
+unsafe extern "Rust" {
+    #[allow(unused)]
+    pub unsafe fn kprint(args: ::core::fmt::Arguments<'_>);
+}
+
+/// Prints formatted text to the VGA display without a
+/// newline.
+///
+/// # Parameters
+/// - `$fmt`: The format string.
+/// - `$arg`: Optional arguments to interpolate into the format string.
+/// - `color = $color`: Optional named parameter to change the VGA text
+///   color for this print.
+#[macro_export]
+macro_rules! print {
+    // Case 1: Standard print with optional arguments.
+    ($fmt:expr $(, $arg:expr)* $(;)?) => {{
+        unsafe { $crate::kprint(format_args!($fmt, $($arg,)*)) }
+    }};
+}
+
+/// Prints formatted text followed by a newline to the VGA
+/// display. Same as the [`print!`] macro just with a `\n`
+/// attached to the end
+#[macro_export]
+macro_rules! println {
+    // Case 1: Standard println with optional arguments.
+    ($fmt:expr $(, $arg:expr)* $(;)?) => {
+        $crate::print!(concat!($fmt, "\n") $(, $arg)*)
+    };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new library providing print and println macros for formatted text output.
  * Added support for no-std VGA text printing in Rust.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->