### PR TITLE
Add simple spinlock mutex.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
     "crates/libk",
     "kernel",
     "tests",
-    "xtask",
+    "xtask", "crates/sync",
     # "snippets",
 ]
 

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "sync"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod mutex;

--- a/crates/sync/src/mutex.rs
+++ b/crates/sync/src/mutex.rs
@@ -1,0 +1,53 @@
+use core::{cell::UnsafeCell, ops::{Deref, DerefMut}, sync::atomic::{AtomicBool, Ordering}};
+
+pub struct SpinLockMutex<T> {
+    locked: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+unsafe impl<T> Sync for SpinLockMutex<T> where T: Send {}
+
+impl<T> SpinLockMutex<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock(&self) -> Guard<'_, T> {
+        // While the lock is `true`, a swap to `true` returns the previous value which is `true`
+        // which keeps the mutex locked.
+        // Only when unlocking, the swap would return `false` which would stop the loop
+        while self.locked.swap(true, Ordering::Acquire) {
+            core::hint::spin_loop();
+        }
+
+        Guard { mutex: self }
+    }
+
+}
+
+pub struct Guard<'a, T> {
+    mutex: &'a SpinLockMutex<T>,
+}
+
+impl<T> Deref for Guard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.mutex.data.get() }
+    }
+}
+
+impl<T> DerefMut for Guard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.mutex.data.get() }
+    }
+}
+
+impl<T> Drop for Guard<'_, T> {
+    fn drop(&mut self) {
+        self.mutex.locked.store(false, Ordering::Release);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new synchronization library providing mutex primitives compatible with no_std environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->