### PR TITLE
Add option to compile specific package with debug assertions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,3 @@ opt-level = 's'
 # overflow-checks = true
 codegen-units = 1
 panic = "abort"
-
-[profile.release.package.buddy]
-inherits = "release"
-debug = true
-debug-assertions = true
-
-[profile.release.package.page]
-inherits = "release"
-debug = true
-debug-assertions = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,11 +16,21 @@ enum Commands {
     Build {
         #[arg(long)]
         release: bool,
+
+        /// Enable debug-assertions/overflow-checks/debug-info for this
+        /// package, even when the rest of the build is in
+        /// --release mode. Can be passed multiple times:
+        /// --debug-package foo --debug-package bar
+        #[arg(long = "debug-package", value_name = "PACKAGE")]
+        debug_packages: Vec<String>,
     },
     /// Build and launch the OS in QEMU
     Run {
         #[arg(long)]
         release: bool,
+
+        #[arg(long = "debug-package", value_name = "PACKAGE")]
+        debug_packages: Vec<String>,
     },
 }
 
@@ -32,19 +42,22 @@ fn main() -> Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .context("Failed to find workspace root")?;
-
     println!("{:?}", root);
-
     sh.change_dir(root);
 
     match cli.command {
-        Commands::Build { release } => sh.build_os(release)?,
-        Commands::Run { release } => {
-            sh.build_os(release)?;
+        Commands::Build {
+            release,
+            debug_packages,
+        } => sh.build_os(release, &debug_packages)?,
+        Commands::Run {
+            release,
+            debug_packages,
+        } => {
+            sh.build_os(release, &debug_packages)?;
             run_qemu()?;
         }
     }
-
     Ok(())
 }
 
@@ -55,8 +68,30 @@ impl Shell {
         manifest: &str,
         target: &str,
         profile: &str,
-        flags: &[&'static str],
+        extra_flags: &[&'static str],
+        debug_packages: &[String],
     ) -> Result<()> {
+        // Build --config overrides for any packages that should keep
+        // debug-assertions/overflow-checks/debug-info even in a release
+        // profile.
+        let overrides: Vec<String> = debug_packages
+            .iter()
+            .flat_map(|pkg| {
+                [
+                    format!(
+                        "profile.{profile}.package.{pkg}.\
+                         debug-assertions=true"
+                    ),
+                    format!(
+                        "profile.{profile}.package.{pkg}.\
+                         overflow-checks=true"
+                    ),
+                    format!("profile.{profile}.package.{pkg}.debug=true"),
+                ]
+            })
+            .flat_map(|kv| ["--config".to_string(), kv])
+            .collect();
+
         cmd!(
             self,
             "
@@ -64,16 +99,21 @@ impl Shell {
                 --manifest-path={manifest}
                 --profile={profile}
                 --target={target}
-             {flags...}
+             {extra_flags...}
+             {overrides...}
             "
         )
         .run()
-        .context("Failed to build first_stage")?;
-
+        .with_context(|| format!("Failed to build {manifest}"))?;
         Ok(())
     }
 
-    fn build_os(&self, release: bool) -> Result<()> {
+    fn build_os(
+        &self,
+        release: bool,
+        debug_packages: &[String],
+    ) -> Result<()> {
+        let profile = if release { "release" } else { "dev" };
         let flags = [
             "-Z",
             "build-std=core,alloc",
@@ -86,52 +126,56 @@ impl Shell {
         self.build_target(
             "bootloader/first_stage/Cargo.toml",
             "bootloader/first_stage/16bit_target.json",
-            "release",
+            profile,
             &flags,
+            debug_packages,
         )?;
-
         self.build_target(
             "bootloader/second_stage/Cargo.toml",
             "bootloader/second_stage/32bit_target.json",
-            "release",
+            profile,
             &flags,
+            debug_packages,
         )?;
-
         self.build_target(
             "kernel/Cargo.toml",
             "kernel/64bit_target.json",
-            "release",
+            profile,
             &flags,
+            debug_packages,
         )?;
 
-        let stage1_bin = "target/16bit_target/release/first_stage";
-        let stage2_bin = "target/32bit_target/release/second_stage";
-        let kernel = "target/64bit_target/release/kernel";
+        // NOTE: profile "dev" -> target dir is `debug`, not the profile
+        // name itself.
+        let profile_dir = if release { "release" } else { "debug" };
+        let stage1_bin =
+            format!("target/16bit_target/{profile_dir}/first_stage");
+        let stage2_bin =
+            format!("target/32bit_target/{profile_dir}/second_stage");
+        let kernel_bin =
+            format!("target/64bit_target/{profile_dir}/kernel");
+
         let mut image =
-            self.read_binary_file(stage1_bin).with_context(|| {
+            self.read_binary_file(&stage1_bin).with_context(|| {
                 format!("Could not find stage1 binary at {}", stage1_bin)
             })?;
-
         let stage2 =
-            self.read_binary_file(stage2_bin).with_context(|| {
+            self.read_binary_file(&stage2_bin).with_context(|| {
                 format!("Could not find stage2 binary at {}", stage2_bin)
             })?;
-
         image.extend(stage2);
-
-        let kernel = self.read_binary_file(kernel).with_context(|| {
-            format!("Could not find kernel binary at {}", kernel)
-        })?;
-
+        let kernel =
+            self.read_binary_file(&kernel_bin).with_context(|| {
+                format!("Could not find kernel binary at {}", kernel_bin)
+            })?;
         image.extend(kernel);
+
         // 4. Padding to MIN_SIZE (512KB + header/offset)
         const MIN_SIZE: usize = 515_585;
         if image.len() < MIN_SIZE {
             image.resize(MIN_SIZE, 0);
         }
-
         self.write_file("image.bin", image)?;
-
         Ok(())
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--debug-package` option to build or run selected packages with additional runtime checks enabled.
  * Supports specifying multiple packages with repeatable options.

* **Bug Fixes**
  * Improved build error messages by identifying the affected output path.
  * Corrected image assembly to use the appropriate debug or release build outputs.

* **Performance**
  * Release builds no longer enable debug information and assertions for selected packages by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->